### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ The 'HTW Dresden App' is a student-initiated project that enables students of th
 <img src="Screenshots/Screenshot_Übersicht.png" alt="overview" width="18%"/><img src="Screenshots/Screenshot_Stundenplan.png" alt="timetable" width="18%"/><img src="Screenshots/Screenshot_Mensa.png" alt="canteen" width="18%"/><img src="Screenshots/Screenshot_Noten.png" alt="grades" width="18%"/> 
 <img src="Screenshots/Screenshot_Campusplan.png" alt="campus plan" width="18%"/>
 
-# Availability
-You can download the app from Google Play Store.
-
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/de_badge_web_generic.png" width="200" alt="Google Play"/>](https://play.google.com/store/apps/details?id=de.htwdd.htwdresden&utm_source=github)
-
 # Credits
 Our credits go to the initiators of this project:
 * [Kay Förster M.Sc.](https://github.com/FestPlatin)
@@ -20,4 +15,4 @@ Our credits go to the initiators of this project:
 * [eikw](https://github.com/eikw)
 
 # Current status
-The app is currently maintained by [Develappers GmbH](https://www.develappers.de/). Feature requests and bugs can be filed by sending an email to the official app related address app@htw-dresden.de of the University of Applied Sciences Dresden. If you want to support this project, you're welcome. You can find general contact information in our [GitHub profile](https://github.com/DevelappersGmbH) or at our website.
+The app is no longer supported. Please use the new webapp "[HTWD mobil](https://mobil.htw-dresden.de/)".


### PR DESCRIPTION
Wem gehört eigentlich dieses Repository?
Die App wird aktuell nicht mehr von der HTW Dresden supported und die Schnittstellen (Noten, Stundenplan etc.) sind bereits abgeschalten.
Die Daten in der README sind nicht aktuell (siehe Pull Request).
Es wäre eigentlich gut, wenn dieses Repo komplett gelöscht werden könnte bzw. zumindest darauf hingewiesen wird, dass das Projekt so nicht fortgesetzt wird.
